### PR TITLE
New features: -o output file, --root, --rename, and --set.  Behavior change: default to no root element.  Fixes #2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,7 @@ Example tool to render a template using data loaded from a YAML
 file.  One intended use case: load an [OSCAL style](https://pages.nist.gov/OSCAL/documentation/schema/ssp/) YAML file and render
 a Jinja2 template to produce the markdown for SSP front matter.
 
-<<<<<<< HEAD
-To better support the above intended use case, by default
-the value of the key 'system_security_plan' in the input values YAML
-is mapped to the template variable 'ssp'.
-
 ## Installation
-=======
-# Usage
->>>>>>> Add option to set output file.  Default to populating Jinja2 vars with all top-level keys from YAML file; add -r and -R options to set root element and rename variables; add -s option to set var from command line.
 
 You can either run this in a self-contained Docker container (recommended) or installed locally using Python.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ Example tool to render a template using data loaded from a YAML
 file.  One intended use case: load an [OSCAL style](https://pages.nist.gov/OSCAL/documentation/schema/ssp/) YAML file and render
 a Jinja2 template to produce the markdown for SSP front matter.
 
+<<<<<<< HEAD
 To better support the above intended use case, by default
 the value of the key 'system_security_plan' in the input values YAML
 is mapped to the template variable 'ssp'.
 
 ## Installation
+=======
+# Usage
+>>>>>>> Add option to set output file.  Default to populating Jinja2 vars with all top-level keys from YAML file; add -r and -R options to set root element and rename variables; add -s option to set var from command line.
 
 You can either run this in a self-contained Docker container (recommended) or installed locally using Python.
 
@@ -49,8 +53,10 @@ secrender --in example-ssp.yaml --template example-ssp.md.j2 >ssp.md
 ## TODO
 
 * would be nice to validate input values against schema
-* root element handling is simplistic
 
 ## License
 
 This project is licensed under the GNU General Public License - see the [LICENSE](LICENSE) file for details.
+
+
+

--- a/example.md.j2
+++ b/example.md.j2
@@ -1,0 +1,7 @@
+Today is {{ date | default('unknown') }}.
+
+My pets:
+
+{% for pet in pets -%}
+- {{ pet.name }} has {{ pet.color }} fur.
+{% endfor %}

--- a/example.yaml
+++ b/example.yaml
@@ -1,0 +1,10 @@
+pets:
+  - dog:
+    name: Rover
+    color: black
+  
+  - cat:
+    name: Felix
+    color: brown
+
+  


### PR DESCRIPTION
Add option to set output file.  Default to populating Jinja2 vars with all top-level keys from YAML file; add -r and -R options to set root element and rename variables; add -s option to set var from command line.